### PR TITLE
Deploy production server to host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 dist/
 hs_err_pid*
 node_modules/
+services/http/srv/images
 target/

--- a/deployments/production/docker-compose.yml
+++ b/deployments/production/docker-compose.yml
@@ -33,7 +33,9 @@ services:
       - api:api
     volumes:
       - dist:/dist
+      - images:/srv/images
       - ${SERVICES_DIR}/http/production.conf:/etc/nginx/conf.d/http.conf
 volumes:
-  pgdata:
   dist:
+  images:
+  pgdata:

--- a/services/http/development.conf
+++ b/services/http/development.conf
@@ -1,19 +1,7 @@
 server {
-    listen 80;
     charset utf-8;
-    location /images/ {
-        autoindex on;
-    }
-    location /mock_api/ {
-        try_files $uri.json $uri;
-    }
-    location /api/ {
-        proxy_pass http://api:8080/;
-        proxy_set_header Host $host:$server_port;
-        proxy_set_header X-Forwarded-Host $server_name;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
+    listen 80;
+    root /srv;
     location / {
         proxy_pass http://app:8080/;
         proxy_set_header Host $host:$server_port;
@@ -22,7 +10,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
         proxy_http_version 1.1;
+    }
+    location /api {
+        proxy_pass http://api:8080/;
+        proxy_set_header Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+    location /mock_api {
+        try_files $uri.json =404;
     }
 }

--- a/services/http/nginx.conf
+++ b/services/http/nginx.conf
@@ -6,7 +6,6 @@ events {
     worker_connections 1024;
 }
 http {
-    root /srv;
     include /etc/nginx/mime.types;
     include /etc/nginx/conf.d/*.conf;
     default_type application/octet-stream;

--- a/services/http/production.conf
+++ b/services/http/production.conf
@@ -1,18 +1,23 @@
 server {
-    listen 80;
     charset utf-8;
-    location /api/ {
+    listen 80;
+    root /dist;
+    server_name yumm.jessywilliams.com;
+    location / {
+        index index.html;
+        try_files $uri @rewrites;
+    }
+    location @rewrites {
+        rewrite ^(.+)$ /index.html last;
+    }
+    location /api {
         proxy_pass http://api:8080/;
         proxy_set_header Host $host:$server_port;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-    location / {
-        root /dist;
-        index index.html;
-        location / {
-            try_files $uri $uri/ =404;
-        }
+    location /images {
+        root /srv;
     }
 }


### PR DESCRIPTION
I've setup http://yumm.jessywilliams.com to serve as the "production" host. It can be update and/ or rolled back to previous versions by running `git checkout [tag/commit sha] && docker-compose up -d --build`

closes #25 