### PR TITLE
Seed USDA Serving Data

### DIFF
--- a/db/2_tables.sql
+++ b/db/2_tables.sql
@@ -40,8 +40,7 @@ CREATE TABLE recipe (
   description TEXT,
   view_count INTEGER DEFAULT 0,
   star_count INTEGER DEFAULT 0,
-  steps TEXT [],
-  ingredients SERVING []
+  steps TEXT []
 );
 
 -- TOKEN -----------------------------------------------------------------------

--- a/db/2_tables.sql
+++ b/db/2_tables.sql
@@ -36,16 +36,13 @@ DROP TABLE IF EXISTS recipe CASCADE;
 CREATE TABLE recipe (
   id SERIAL PRIMARY KEY,
   account_id INTEGER REFERENCES account NOT NULL,
-  serving_count REAL NOT NULL,
-  serving_size TEXT NOT NULL,
   categories RECIPE_CATEGORY [],
   description TEXT,
   view_count INTEGER DEFAULT 0,
   star_count INTEGER DEFAULT 0,
   steps TEXT [],
-  ingredient_ids INTEGER[]
+  ingredients SERVING []
 );
-
 
 -- TOKEN -----------------------------------------------------------------------
 DROP TABLE IF EXISTS token CASCADE;
@@ -60,6 +57,8 @@ DROP TABLE IF EXISTS food CASCADE;
 CREATE TABLE food (
   id SERIAL PRIMARY KEY,
   title TEXT NOT NULL,
+  serving_count REAL NOT NULL DEFAULT 0,
+  serving_size TEXT,
   nutrition_id INTEGER REFERENCES nutrition UNIQUE,
   recipe_id INTEGER REFERENCES recipe UNIQUE,
   time_created TIMESTAMP DEFAULT now() NOT NULL,

--- a/db/3_seeding.sql
+++ b/db/3_seeding.sql
@@ -42,7 +42,6 @@ ALTER TABLE usda.products
 INSERT INTO food (usda_id, title)
 SELECT ndb_number, initcap(long_name)
 FROM usda.products
-JOIN usda.servings ON usda.products.ndb_number = usda.servings.ndb_no
 ON CONFLICT ON CONSTRAINT title_const DO NOTHING;
 
 -- Add serving size data


### PR DESCRIPTION
# Summary

- Removes`ingredient_ids` from recipe table
- Moves `serving_count` and `serving_size` columns from nutrition table to food
- Seeds serving data from USDA CSVs

![image](https://user-images.githubusercontent.com/4343678/48088134-2b8de700-e1cf-11e8-8640-209120525317.png)

# Notes

In order to reinitialize your database run the following
1. `docker-compose down`
2. `docker-compose volume rm cis4250_pgdata`
3. `dcoker-compose up --build db`

Not optimized for performance. A regex filter is applied to `serving_size` which may need to be revised to better clear out garbage from strings.