### PR TITLE
link between recipe and food via serving quantity table

### DIFF
--- a/db/2_tables.sql
+++ b/db/2_tables.sql
@@ -68,7 +68,7 @@ DROP TABLE IF EXISTS servings CASCADE;
 CREATE TABLE servings (
   recipe_id INTEGER REFERENCES recipe NOT NULL,
   food_id INTEGER REFERENCES food NOT NULL,
-  quantity INTEGER DEFAULT 0,
+  quantity REAL DEFAULT 0,
   PRIMARY KEY(food_id, recipe_id)
 );
 

--- a/db/2_tables.sql
+++ b/db/2_tables.sql
@@ -59,10 +59,19 @@ CREATE TABLE food (
   serving_count REAL NOT NULL DEFAULT 0,
   serving_size TEXT,
   nutrition_id INTEGER REFERENCES nutrition UNIQUE,
-  recipe_id INTEGER REFERENCES recipe UNIQUE,
   time_created TIMESTAMP DEFAULT now() NOT NULL,
   time_updated TIMESTAMP DEFAULT now() NOT NULL
 );
+
+-- Servings --------------------------------------------------------------------
+DROP TABLE IF EXISTS servings CASCADE;
+CREATE TABLE servings (
+  recipe_id INTEGER REFERENCES recipe NOT NULL,
+  food_id INTEGER REFERENCES food NOT NULL,
+  quantity INTEGER DEFAULT 0,
+  PRIMARY KEY(food_id, recipe_id)
+);
+
 
 -- Create a GIN index for food table's title row
 ALTER TABLE food ADD COLUMN IF NOT EXISTS tsv_food_title tsvector;


### PR DESCRIPTION
# Summary

This PR is simply adding a table that can be used as a link between the recipe and food tables. The table only consists of a composite key with recipe_id and food_id, as well as a quantity field to specify quantity of food_id entries. I also removed the recipe_id field from the food table, as it was currently doing nothing.
